### PR TITLE
Web interface configuration

### DIFF
--- a/firmware/.vscode/settings.json
+++ b/firmware/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "optional": "cpp",
+        "system_error": "cpp"
+    }
+}

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -21,6 +21,7 @@ framework = arduino
 lib_deps = 
 	knolleary/pubsubclient@2.8
 	bblanchon/ArduinoJson@^6.20.1
+	https://github.com/me-no-dev/ESPAsyncWebServer.git
 
 [env:featheresp32]
 monitor_speed = 115200

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -32,4 +32,5 @@ framework = arduino
 lib_deps = 
 	knolleary/pubsubclient@2.8
 	bblanchon/ArduinoJson@^6.20.1
+	https://github.com/me-no-dev/ESPAsyncWebServer.git
 

--- a/firmware/src/configuration.h
+++ b/firmware/src/configuration.h
@@ -7,8 +7,8 @@
 
 #define MQTT_SERVER_HOST "<PUT HERE YOUR MQTT SERVER DOMAIN or IP>"
 #define MQTT_SERVER_PORT 1883
-#define MQTT_SERVER_USERNAME NULL // You can provide username for MQTT server if needed
-#define MQTT_SERVER_PASSWORD NULL // You can provide password for MQTT server if needed
+#define MQTT_SERVER_USERNAME "" // You can provide username for MQTT server if needed
+#define MQTT_SERVER_PASSWORD "" // You can provide password for MQTT server if needed
 #define MQTT_CLIENT_TOPIC "wifi2mqtt/air_recuperation"
 #define MQTT_CLIENT_ID "BelimoCRAB1P"
 

--- a/firmware/src/configuration.h
+++ b/firmware/src/configuration.h
@@ -2,10 +2,10 @@
 
 #include <Arduino.h>
 
-#define WIFI_SSID "<PUT HERE YOUR WIFI SSID>"
-#define WIFI_PASSWORD "<PUT HERE YOUR WIFI PASSWORD>"
+#define WIFI_SSID "[PUT HERE YOUR WIFI SSID]"
+#define WIFI_PASSWORD "[PUT HERE YOUR WIFI PASSWORD]"
 
-#define MQTT_SERVER_HOST "<PUT HERE YOUR MQTT SERVER DOMAIN or IP>"
+#define MQTT_SERVER_HOST "[PUT HERE YOUR MQTT SERVER DOMAIN or IP]"
 #define MQTT_SERVER_PORT 1883
 #define MQTT_SERVER_USERNAME "" // You can provide username for MQTT server if needed
 #define MQTT_SERVER_PASSWORD "" // You can provide password for MQTT server if needed

--- a/firmware/src/configurationServer.cpp
+++ b/firmware/src/configurationServer.cpp
@@ -1,0 +1,41 @@
+#include "configurationServer.h"
+
+
+ConfigurationServer::ConfigurationServer(Settings* settings)
+{
+    WiFi.softAP(settings->mqttClientId.c_str());
+    this->server = new AsyncWebServer(80);
+
+    this->server->on("/", HTTP_GET, [this, &settings](AsyncWebServerRequest *request) {
+        request->send(200, "text/html", this->generateIndexPage(settings));
+    });
+
+    server->on("/credentials", HTTP_POST, [&settings](AsyncWebServerRequest *request) {
+        request->send(200, "text/plain", "Credentials updated.");
+        
+        const String wifiUsername = request->getParam("wifi_username")->value();
+        const String wifiPassword = request->getParam("wifi_password")->value();
+        const String mqttHost = request->getParam("mqtt_host")->value();
+        const String mqttPort = request->getParam("mqtt_port")->value();
+        const String mqttUsername = request->getParam("mqtt_username")->value();
+        const String mqttPassword = request->getParam("mqtt_password")->value();
+        const String mqttId = request->getParam("mqtt_id")->value();
+        const String mqttTopic = request->getParam("mqtt_topic")->value();
+
+        settings->wifiUsername = wifiUsername;
+        settings->wifiPassword = wifiPassword;
+        settings->mqttServerHost = mqttHost;
+        settings->mqttServerPort = (uint16_t)atoi(mqttPort.c_str());
+        settings->mqttServerUsername = mqttUsername;
+        settings->mqttServerPassword = mqttPassword;
+        settings->mqttClientId = mqttId;
+        settings->mqttClientTopic = mqttTopic;
+        settings->store();
+        
+        delay(1000);
+
+        ESP.restart();
+    });
+
+    this->server->begin();
+}

--- a/firmware/src/configurationServer.cpp
+++ b/firmware/src/configurationServer.cpp
@@ -1,28 +1,80 @@
 #include "configurationServer.h"
 
-
-ConfigurationServer::ConfigurationServer(Settings* settings)
+String ConfigurationServer::generateIndexPage(Settings* settings)
 {
+    String indexPage = "<html>"
+        "<body>"
+            "<form method='POST' action='/credentials'>"
+                "<table>"
+                    "<tr>"
+                        "<td>Wifi SSID:</td>"
+                        "<td><input type='textbox' name='wifi_ssid' value='" + settings->wifiSSID + "'></td>"
+                    "</tr>"
+                    "<tr>"
+                        "<td>Wifi password:</td>"
+                        "<td><input type='password' name='wifi_password'></td>"
+                    "</tr>"
+                    "<tr>"
+                        "<td>Mqtt host:</td>"
+                        "<td><input type='textbox' name='mqtt_host' value='" + settings->mqttServerHost + "'></td>"
+                    "</tr>"
+                    "<tr>"
+                        "<td>Mqtt port:</td>"
+                        "<td><input type='textbox' name='mqtt_port' value='" + settings->mqttServerPort + "'></td>"
+                    "</tr>"
+                    "<tr>"
+                        "<td>Mqtt username:</td>"
+                        "<td><input type='textbox' name='mqtt_username' value='" + settings->mqttServerUsername + "'></td>"
+                    "</tr>"
+                    "<tr>"
+                        "<td>Mqtt password:</td>"
+                        "<td><input type='password' name='mqtt_password'></td>"
+                    "</tr>"
+                    "<tr>"
+                        "<td>Mqtt id:</td>"
+                        "<td><input type='textbox' name='mqtt_id' value='" + settings->mqttClientId + "'></td>"
+                    "</tr>"
+                    "<tr>"
+                        "<td>Mqtt topic:</td>"
+                        "<td><input type='textbox' name='mqtt_topic' value='" + settings->mqttClientTopic + "'></td>"
+                    "</tr>"
+                "</table>"
+                "<input type='submit' value='Update'>"
+            "</form>"
+        "</body>"
+    "</html>";
+
+    return indexPage;
+}
+
+ConfigurationServer::ConfigurationServer(Settings* settings, HardwareSerial* serial)
+{
+    String indexPage = this->generateIndexPage(settings);
+
+    serial->println("Starting WIFI access point ....");
+    WiFi.mode(WIFI_AP);
     WiFi.softAP(settings->mqttClientId.c_str());
+
+    serial->print("AP Created with IP: ");
+    serial->println(WiFi.softAPIP());
+
     this->server = new AsyncWebServer(80);
 
-    this->server->on("/", HTTP_GET, [this, &settings](AsyncWebServerRequest *request) {
-        request->send(200, "text/html", this->generateIndexPage(settings));
+    this->server->on("/", HTTP_GET, [indexPage](AsyncWebServerRequest *request) {
+        request->send(200, "text/html", indexPage);
     });
 
-    server->on("/credentials", HTTP_POST, [&settings](AsyncWebServerRequest *request) {
-        request->send(200, "text/plain", "Credentials updated.");
-        
-        const String wifiUsername = request->getParam("wifi_username")->value();
-        const String wifiPassword = request->getParam("wifi_password")->value();
-        const String mqttHost = request->getParam("mqtt_host")->value();
-        const String mqttPort = request->getParam("mqtt_port")->value();
-        const String mqttUsername = request->getParam("mqtt_username")->value();
-        const String mqttPassword = request->getParam("mqtt_password")->value();
-        const String mqttId = request->getParam("mqtt_id")->value();
-        const String mqttTopic = request->getParam("mqtt_topic")->value();
+    server->on("/credentials", HTTP_POST, [settings](AsyncWebServerRequest *request) {
+        const String wifiSSID = request->getParam("wifi_ssid", true)->value();
+        const String wifiPassword = request->getParam("wifi_password", true)->value();
+        const String mqttHost = request->getParam("mqtt_host", true)->value();
+        const String mqttPort = request->getParam("mqtt_port", true)->value();
+        const String mqttUsername = request->getParam("mqtt_username", true)->value();
+        const String mqttPassword = request->getParam("mqtt_password", true)->value();
+        const String mqttId = request->getParam("mqtt_id", true)->value();
+        const String mqttTopic = request->getParam("mqtt_topic", true)->value();
 
-        settings->wifiUsername = wifiUsername;
+        settings->wifiSSID = wifiSSID;
         settings->wifiPassword = wifiPassword;
         settings->mqttServerHost = mqttHost;
         settings->mqttServerPort = (uint16_t)atoi(mqttPort.c_str());
@@ -31,6 +83,8 @@ ConfigurationServer::ConfigurationServer(Settings* settings)
         settings->mqttClientId = mqttId;
         settings->mqttClientTopic = mqttTopic;
         settings->store();
+
+        request->send(200, "text/plain", "Credentials updated.");
         
         delay(1000);
 

--- a/firmware/src/configurationServer.h
+++ b/firmware/src/configurationServer.h
@@ -7,54 +7,8 @@ class ConfigurationServer
 {
     private:
         AsyncWebServer* server;
-
-        String generateIndexPage(Settings* settings)
-        {
-            String indexPage = "<html>"
-                "<body>"
-                    "<form method='POST' action='/credentials'>"
-                        "<table>"
-                            "<tr>"
-                                "<td>Wifi username:</td>"
-                                "<td><input type='textbox' name='wifi_username' value='" + settings->wifiUsername + "'></td>"
-                            "</tr>"
-                            "<tr>"
-                                "<td>Wifi password:</td>"
-                                "<td><input type='password' name='wifi_password'></td>"
-                            "</tr>"
-                            "<tr>"
-                                "<td>Mqtt host:</td>"
-                                "<td><input type='textbox' name='mqtt_host value='" + settings->mqttServerHost + "'></td>"
-                            "</tr>"
-                            "<tr>"
-                                "<td>Mqtt port:</td>"
-                                "<td><input type='textbox' name='mqtt_port value='" + settings->mqttServerPort + "'></td>"
-                            "</tr>"
-                            "<tr>"
-                                "<td>Mqtt username:</td>"
-                                "<td><input type='textbox' name='mqtt_username value='" + settings->mqttServerUsername + "'></td>"
-                            "</tr>"
-                            "<tr>"
-                                "<td>Mqtt password:</td>"
-                                "<td><input type='password' name='mqtt_password'></td>"
-                            "</tr>"
-                            "<tr>"
-                                "<td>Mqtt id:</td>"
-                                "<td><input type='textbox' name='mqtt_id value='" + settings->mqttClientId + "'></td>"
-                            "</tr>"
-                            "<tr>"
-                                "<td>Mqtt topic:</td>"
-                                "<td><input type='textbox' name='mqtt_topic value='" + settings->mqttClientTopic + "'></td>"
-                            "</tr>"
-                        "</table>"
-                        "<input type='submit' value='Update'>"
-                    "</form>"
-                "</body>"
-            "</html>";
-
-            return indexPage;
-        }
+        String generateIndexPage(Settings* settings);
 
     public:
-        ConfigurationServer(Settings* settings);
+        ConfigurationServer(Settings* settings, HardwareSerial* serial);
 };

--- a/firmware/src/configurationServer.h
+++ b/firmware/src/configurationServer.h
@@ -1,0 +1,60 @@
+#pragma once
+#include "settings.h"
+#include <ESPAsyncWebServer.h>
+
+
+class ConfigurationServer
+{
+    private:
+        AsyncWebServer* server;
+
+        String generateIndexPage(Settings* settings)
+        {
+            String indexPage = "<html>"
+                "<body>"
+                    "<form method='POST' action='/credentials'>"
+                        "<table>"
+                            "<tr>"
+                                "<td>Wifi username:</td>"
+                                "<td><input type='textbox' name='wifi_username' value='" + settings->wifiUsername + "'></td>"
+                            "</tr>"
+                            "<tr>"
+                                "<td>Wifi password:</td>"
+                                "<td><input type='password' name='wifi_password'></td>"
+                            "</tr>"
+                            "<tr>"
+                                "<td>Mqtt host:</td>"
+                                "<td><input type='textbox' name='mqtt_host value='" + settings->mqttServerHost + "'></td>"
+                            "</tr>"
+                            "<tr>"
+                                "<td>Mqtt port:</td>"
+                                "<td><input type='textbox' name='mqtt_port value='" + settings->mqttServerPort + "'></td>"
+                            "</tr>"
+                            "<tr>"
+                                "<td>Mqtt username:</td>"
+                                "<td><input type='textbox' name='mqtt_username value='" + settings->mqttServerUsername + "'></td>"
+                            "</tr>"
+                            "<tr>"
+                                "<td>Mqtt password:</td>"
+                                "<td><input type='password' name='mqtt_password'></td>"
+                            "</tr>"
+                            "<tr>"
+                                "<td>Mqtt id:</td>"
+                                "<td><input type='textbox' name='mqtt_id value='" + settings->mqttClientId + "'></td>"
+                            "</tr>"
+                            "<tr>"
+                                "<td>Mqtt topic:</td>"
+                                "<td><input type='textbox' name='mqtt_topic value='" + settings->mqttClientTopic + "'></td>"
+                            "</tr>"
+                        "</table>"
+                        "<input type='submit' value='Update'>"
+                    "</form>"
+                "</body>"
+            "</html>";
+
+            return indexPage;
+        }
+
+    public:
+        ConfigurationServer(Settings* settings);
+};

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -30,7 +30,7 @@ void setup() {
 
     if (!mqttClient->initialise(settings))
     {
-        configurationServer = new ConfigurationServer(settings);
+        configurationServer = new ConfigurationServer(settings, &Serial);
     }
     else
     {

--- a/firmware/src/mqttClient.cpp
+++ b/firmware/src/mqttClient.cpp
@@ -1,0 +1,96 @@
+#include "mqttClient.h"
+#include <ArduinoJson.h>
+
+MqttClient::MqttClient(Recuperation* recuperation, HardwareSerial* serial)
+{
+    this->recuperation = recuperation;
+    this->serial = serial;
+    this->wiFiClient = new WiFiClient();
+    this->client = new PubSubClient(*this->wiFiClient);
+}
+
+void MqttClient::callback(char* topic, byte* payload, unsigned int length) {
+    char* message = (char*) payload;
+
+    StaticJsonDocument<200> doc;
+    DeserializationError error = deserializeJson(doc, payload, length);
+    
+    if (error) {
+        this->serial->print("Failed to parse JSON data: ");
+        this->serial->println(error.c_str());
+        return;
+    }
+    
+    uint8_t source = doc["source"];
+
+    if (source == 0) {
+        return;
+    }
+
+    uint8_t selectedState = doc["air_flow_state"];
+
+    recuperation->setState(selectedState);
+}
+
+bool MqttClient::initialise(Settings* settings)
+{
+    settings->read();
+    this->mqttTopic = settings->mqttClientTopic.c_str();
+
+    WiFi.begin(settings->wifiUsername.c_str(), settings->wifiPassword.c_str());
+    int8_t wifiRetryCount = 0;
+    for (wifiRetryCount = 0; wifiRetryCount < 10 && WiFi.status() != WL_CONNECTED; wifiRetryCount++) {
+        delay(1000);
+        this->serial->println("Connecting to WiFi...");
+    }
+
+    if (wifiRetryCount >= 10) {
+        return false;
+    }
+
+    this->serial->println("Connected to WiFi");
+    
+    this->client->setServer(settings->mqttServerHost.c_str(), settings->mqttServerPort);
+
+    using std::placeholders::_1;
+    using std::placeholders::_2;
+    using std::placeholders::_3;
+    this->client->setCallback(std::bind(&MqttClient::callback, this, _1, _2, _3));
+
+    int8_t mqttRetryCount = 0;
+    for (mqttRetryCount = 0; mqttRetryCount < 10 && !this->client->connected(); mqttRetryCount++) {
+        this->serial->println("Connecting to MQTT server...");
+        if (this->client->connect(settings->mqttClientId.c_str(), settings->mqttServerUsername.c_str(), settings->mqttServerPassword.c_str() )) {
+            this->serial->println("Connected to MQTT server");
+            this->client->subscribe(settings->mqttClientTopic.c_str());
+        }
+        else {
+            this->serial->print("Failed with state ");
+            this->serial->print(this->client->state());
+            delay(2000);
+        }
+    }
+
+    if (mqttRetryCount >= 10) {
+        return false;
+    }
+
+    return true;
+}
+
+void MqttClient::processState(uint8_t state)
+{
+    if (this->sentState != state) {
+        this->sentState = state;
+       
+        char payload[41];
+        snprintf(payload, 41, "{\"air_flow_state\": %d, \"source\": 0}", state);
+
+        this->serial->println("Sending payload:");
+        this->serial->println(payload);
+        client->publish(this->mqttTopic, payload);
+        this->serial->println(payload);
+    }
+
+    client->loop();
+}

--- a/firmware/src/mqttClient.cpp
+++ b/firmware/src/mqttClient.cpp
@@ -37,7 +37,7 @@ bool MqttClient::initialise(Settings* settings)
     settings->read();
     this->mqttTopic = settings->mqttClientTopic.c_str();
 
-    WiFi.begin(settings->wifiUsername.c_str(), settings->wifiPassword.c_str());
+    WiFi.begin(settings->wifiSSID.c_str(), settings->wifiPassword.c_str());
     int8_t wifiRetryCount = 0;
     for (wifiRetryCount = 0; wifiRetryCount < 10 && WiFi.status() != WL_CONNECTED; wifiRetryCount++) {
         delay(1000);
@@ -45,6 +45,7 @@ bool MqttClient::initialise(Settings* settings)
     }
 
     if (wifiRetryCount >= 10) {
+        this->serial->println("Giving up connecting to wifi.");
         return false;
     }
 

--- a/firmware/src/mqttClient.h
+++ b/firmware/src/mqttClient.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "recuperation.h"
+#include <WiFi.h>
+#include <PubSubClient.h>
+#include "settings.h"
+
+class MqttClient {
+    private:
+        Recuperation* recuperation;
+        HardwareSerial* serial;
+        WiFiClient* wiFiClient;
+        PubSubClient* client;
+        uint8_t sentState = -1;
+        const char* mqttTopic = NULL;
+
+        void callback(char* topic, byte* payload, unsigned int length);
+
+    public:
+        MqttClient(Recuperation* recuperation, HardwareSerial* serial);
+        bool initialise(Settings* settings);
+        void processState(uint8_t state);
+};

--- a/firmware/src/settings.cpp
+++ b/firmware/src/settings.cpp
@@ -17,7 +17,7 @@ Settings::Settings(String defaultWifiSSID, String defaultWifiPassword, String de
 void Settings::read()
 {
     this->preferences->begin("credentials", true); 
-    this->wifiUsername = preferences->getString("wifiUsername", this->defaultWifiSSID);
+    this->wifiSSID = preferences->getString("wifiSSID", this->defaultWifiSSID);
     this->wifiPassword = preferences->getString("wifiPassword", this->defaultWifiPassword);
     this->mqttServerHost = preferences->getString("mqttServerHost", this->defaultMqttServerHost);
     this->mqttServerPort = preferences->getUShort("mqttServerPort", this->defaultMqttServerPort);
@@ -32,7 +32,7 @@ void Settings::read()
 void Settings::store()
 {
     this->preferences->begin("credentials", false); 
-    preferences->putString("wifiUsername", this->wifiUsername);
+    preferences->putString("wifiSSID", this->wifiSSID);
     preferences->putString("wifiPassword", this->wifiPassword);
     preferences->putString("mqttServerHost", this->mqttServerHost);
     preferences->putUShort("mqttServerPort", this->mqttServerPort);

--- a/firmware/src/settings.cpp
+++ b/firmware/src/settings.cpp
@@ -1,0 +1,44 @@
+#include "settings.h"
+
+Settings::Settings(String defaultWifiSSID, String defaultWifiPassword, String defaultServerHost, uint16_t defaultServerPort, String defaultMqttServerUsername, String defaultMqttServerPassword, String defaultMqttClientId, String defaultMqttClientTopic)
+{
+    this->defaultWifiSSID = defaultWifiSSID;
+    this->defaultWifiPassword = defaultWifiPassword;
+    this->defaultMqttServerHost = defaultServerHost;
+    this->defaultMqttServerPort = defaultServerPort;
+    this->defaultMqttServerUsername = mqttServerUsername;
+    this->defaultMqttServerPassword = mqttServerPassword;
+    this->defaultMqttClientId = defaultMqttClientId;
+    this->defaultMqttClientTopic = defaultMqttClientTopic;
+
+    this->preferences = new Preferences();
+}
+
+void Settings::read()
+{
+    this->preferences->begin("credentials", true); 
+    this->wifiUsername = preferences->getString("wifiUsername", this->defaultWifiSSID);
+    this->wifiPassword = preferences->getString("wifiPassword", this->defaultWifiPassword);
+    this->mqttServerHost = preferences->getString("mqttServerHost", this->defaultMqttServerHost);
+    this->mqttServerPort = preferences->getUShort("mqttServerPort", this->defaultMqttServerPort);
+    this->mqttServerUsername = preferences->getString("mqttServerUsername", this->defaultMqttServerUsername);
+    this->mqttServerPassword = preferences->getString("mqttServerPassword", this->defaultMqttServerPassword);
+    this->mqttClientId = preferences->getString("mqttClientId", this->defaultMqttClientId);
+    this->mqttClientTopic = preferences->getString("mqttClientTopic", this->defaultMqttClientTopic);
+    this->preferences->end();
+
+}
+
+void Settings::store()
+{
+    this->preferences->begin("credentials", false); 
+    preferences->putString("wifiUsername", this->wifiUsername);
+    preferences->putString("wifiPassword", this->wifiPassword);
+    preferences->putString("mqttServerHost", this->mqttServerHost);
+    preferences->putUShort("mqttServerPort", this->mqttServerPort);
+    preferences->putString("mqttServerUsername", this->mqttServerUsername);
+    preferences->putString("mqttServerPassword", this->mqttServerPassword);
+    preferences->putString("mqttClientId", this->mqttClientId);
+    preferences->putString("mqttClientTopic", this->mqttClientTopic);
+    this->preferences->end();
+}

--- a/firmware/src/settings.h
+++ b/firmware/src/settings.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <Preferences.h>
+
+class Settings
+{
+    private:
+        Preferences* preferences;
+        String defaultWifiSSID;
+        String defaultWifiPassword;
+        String defaultMqttServerHost;
+        uint16_t defaultMqttServerPort;
+        String defaultMqttServerUsername;
+        String defaultMqttServerPassword;
+        String defaultMqttClientId;
+        String defaultMqttClientTopic;
+
+    public:
+        String wifiUsername;
+        String wifiPassword;
+        String mqttServerHost;
+        uint16_t mqttServerPort;
+        String mqttServerUsername;
+        String mqttServerPassword;
+        String mqttClientId;
+        String mqttClientTopic;
+
+        Settings(String defaultWifiSSID, String defaultWifiPassword, String defaultMqttServerHost, uint16_t defaultMqttServerPort, String defaultMqttServerUsername, String defaultMqttServerPassword, String defaultMqttClientId, String defaultMqttClientTopic);
+
+        void read();
+        void store();
+};

--- a/firmware/src/settings.h
+++ b/firmware/src/settings.h
@@ -15,7 +15,7 @@ class Settings
         String defaultMqttClientTopic;
 
     public:
-        String wifiUsername;
+        String wifiSSID;
         String wifiPassword;
         String mqttServerHost;
         uint16_t mqttServerPort;


### PR DESCRIPTION
When device cannot connect to wifi or MQTT server in 10 tries (10 tries for each), then instead of continuing trying to connect it establishes access point. Access point has same name as picked MQTT ID.

After connecting to wifi access point you can check IP address of the gateway. On this address you can find configuration web interface which allows you to change wifi name, password, etc.

Values in configuration.h file serves as default values now. Values from web interface are overriding them. This allow easy update of password etc. when needed without disassembling the device and reflashing the firmware.